### PR TITLE
Update next branch to reflect new release-train "v2.1.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="2.0.0-next.0"></a>
+# 2.0.0-next.0 (2022-12-22)
+### 
+| Commit | Type | Description |
+| -- | -- | -- |
+| [c3a0b9a](https://github.com/angular/dev-infra-test-release/commit/c3a0b9a5091023f9a31acd9963f03e7db7d79819) | feat | update dev-infra to test https://github.com/angular/dev-infra/pull/719 |
+## Special Thanks
+Joey Perrott and Paul Gschwendtner
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="1.0.1"></a>
 # 1.0.1 (2022-07-15)
 ## Special Thanks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-infra-test-release",
-  "version": "2.0.0-next.0",
+  "version": "2.1.0-next.0",
   "main": "index.js",
   "private": true,
   "repository": "https://github.com/angular/dev-infra-test-release.git",


### PR DESCRIPTION
The previous "next" release-train has moved into the feature-freeze phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v2.0.0-next.0 into the main branch so that the changelog is up to date.