### PR TITLE
docs: release notes for the v1.1.0-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="1.1.0-rc.0"></a>
+# 1.1.0-rc.0 (2022-12-22)
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [7a47020](https://github.com/angular/dev-infra-test-release/commit/7a47020cd97e20219d5fbb43c194bf66516e6929) | feat | support newer TS versions |
+| [8c51b1b](https://github.com/angular/dev-infra-test-release/commit/8c51b1bebbaab20768be908a38f6dc078cdfd038) | fix | patch change |
+## Special Thanks
+Paul Gschwendtner
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="1.0.3"></a>
 # 1.0.3 (2022-12-22)
 ## Special Thanks


### PR DESCRIPTION
Cherry-picks the changelog from the "1.1.x" branch to the next branch (main).